### PR TITLE
Fix translations and dynamic page titles

### DIFF
--- a/static/lang.js
+++ b/static/lang.js
@@ -1,0 +1,26 @@
+window.currentLang = localStorage.getItem('lang') || 'zh';
+function applyLang(){
+  if(window.currentLang === 'en'){
+    document.querySelectorAll('.lang-zh').forEach(el=>el.style.display='none');
+    document.querySelectorAll('.lang-en').forEach(el=>el.style.display='');
+  }else{
+    document.querySelectorAll('.lang-en').forEach(el=>el.style.display='none');
+    document.querySelectorAll('.lang-zh').forEach(el=>el.style.display='');
+  }
+  document.body.dispatchEvent(new Event('langChanged'));
+}
+document.addEventListener('DOMContentLoaded',applyLang);
+document.addEventListener('DOMContentLoaded',function(){
+  var btn=document.getElementById('langToggle');
+  if(btn){
+    btn.addEventListener('click',function(){
+      window.currentLang = window.currentLang==='zh'?'en':'zh';
+      localStorage.setItem('lang',window.currentLang);
+      applyLang();
+    });
+  }
+});
+
+window.t = function(zh,en){
+  return (window.currentLang==='en'? en : zh);
+};

--- a/static/script.js
+++ b/static/script.js
@@ -114,7 +114,7 @@ $(document).ready(function(){
       document.execCommand("copy");
       tempElement.remove();
 
-      showToast("复制成功");
+      showToast(t('复制成功','Copied'));
     });
 
     // 导出
@@ -144,7 +144,7 @@ $(document).ready(function(){
       var workbook = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(workbook, worksheet, "OrderList");
       XLSX.writeFile(workbook, "order_list.xlsx");
-      showToast("导出成功");
+      showToast(t('导出成功','Exported'));
     });
 
     // 打开、关闭扫描
@@ -183,7 +183,7 @@ $(document).ready(function(){
         }
         // 再次调整列宽，保持对齐
         orderTable.columns.adjust();
-        showToast("添加成功");
+        showToast(t('添加成功','Added')); 
         
         // 隐藏数量调整，重置
         $("#quantityModal").addClass("d-none");
@@ -215,7 +215,7 @@ $(document).ready(function(){
 
     // 刷新关闭提示
     window.onbeforeunload = function(e) {
-        return "确定要刷新或关闭吗？未保存的数据可能会丢失。";
+        return t('确定要刷新或关闭吗？未保存的数据可能会丢失。','Leave page? Unsaved data may be lost.');
     };
 
     // modal事件
@@ -252,9 +252,9 @@ function openScannerModal(){
     $("#loadingIndicator").removeClass("d-none");
     $("#loadingIndicator").html(`
         <div class="spinner-border text-light" role="status">
-            <span class="visually-hidden">加载中...</span>
+            <span class="visually-hidden"><span class="lang-zh">加载中...</span><span class="lang-en">Loading...</span></span>
         </div>
-        <p>正在启动摄像头...</p>
+        <p><span class="lang-zh">正在启动摄像头...</span><span class="lang-en">Starting camera...</span></p>
     `);
     
     // 检查是否支持 BarcodeDetector API
@@ -684,13 +684,13 @@ function handleScannerError(err){
     $("#scanner-container").html(`
         <div class="scanner-error">
             <i class="fas fa-exclamation-triangle"></i>
-            <p>无法访问摄像头</p>
+            <p><span class="lang-zh">无法访问摄像头</span><span class="lang-en">Cannot access camera</span></p>
             <ul class="text-start">
-                <li>您已授予摄像头访问权限</li>
-                <li>您使用的是HTTPS连接</li>
-                <li>您的设备有可用的摄像头</li>
+                <li><span class="lang-zh">您已授予摄像头访问权限</span><span class="lang-en">Camera permission granted</span></li>
+                <li><span class="lang-zh">您使用的是HTTPS连接</span><span class="lang-en">Using HTTPS connection</span></li>
+                <li><span class="lang-zh">您的设备有可用的摄像头</span><span class="lang-en">Device has a camera</span></li>
             </ul>
-            <button class="btn btn-primary mt-3" onclick="requestCameraPermission()">重试访问摄像头</button>
+            <button class="btn btn-primary mt-3" onclick="requestCameraPermission()"><span class="lang-zh">重试访问摄像头</span><span class="lang-en">Retry Camera Access</span></button>
         </div>
     `);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -228,7 +228,7 @@ h1 {
     max-width: 350px;
     text-align: center;
     box-shadow: 0 15px 35px rgba(0,0,0,0.3);
-    z-index: 1100;
+    z-index: 2000;
 }
 
 .scanned-info {
@@ -574,7 +574,7 @@ h1 {
 
 #ocrScannerBox {
     position: absolute;
-    top: 50%;
+    top: 45%;
     left: 50%;
     transform: translate(-50%, -50%);
     z-index: 900;
@@ -740,6 +740,11 @@ h1 {
 #ocrOverlayText{
     margin-top:0 !important;
     top:0.6rem !important;
+    background: rgba(0,0,0,0.6);
+    padding:4px 10px;
+    border-radius:12px;
+    color:#fff;
+    z-index:1201;
 }
 
 /* 搜索框清除按钮 hover 效果 */
@@ -756,3 +761,22 @@ h1 {
 /* OCR 手电筒按钮 */
 #flashToggleInOcr.btn-success{background-color:#28a745 !important;}
 #flashToggleInOcr.btn-danger{background-color:#dc3545 !important;}
+
+/* 语言切换悬浮球 */
+.lang-fab{
+    position:fixed;
+    bottom:20px;
+    right:20px;
+    width:48px;
+    height:48px;
+    border-radius:50%;
+    background:#4361ee;
+    color:#fff;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-size:1.2rem;
+    box-shadow:0 4px 12px rgba(0,0,0,0.25);
+    z-index:1500;
+}
+.lang-fab:hover{background:#3554d1;color:#fff;text-decoration:none;}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <!-- 禁止双指放大和双击放大，max-scale=1.0 -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>点货系统</title>
+    <title id="pageTitle">点货系统</title>
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css">
     <!-- Font Awesome -->
@@ -16,7 +16,7 @@
 </head>
 <body>
     <div class="container my-3">
-        <h1 class="text-center">订单列表</h1>
+        <h1 class="text-center"><span class="lang-zh">订单列表</span><span class="lang-en">Order List</span></h1>
         <table id="orderTable" class="display">
             <thead>
                 <tr>
@@ -31,7 +31,7 @@
         <!-- 在表格下方添加手动添加按钮 -->
         <div class="text-center mt-3">
             <button id="addManualBtn" class="btn btn-outline-primary">
-                <i class="fas fa-plus"></i> 手动添加
+                <i class="fas fa-plus"></i> <span class="lang-zh">手动添加</span><span class="lang-en">Add Manually</span>
             </button>
         </div>
     </div>
@@ -40,15 +40,15 @@
     <div class="bottom-buttons">
         <button id="scanBtn" class="btn btn-primary">
             <i class="fas fa-barcode"></i>
-            <span>扫描</span>
+            <span class="lang-zh">扫描</span><span class="lang-en">Scan</span>
         </button>
         <button id="copyBtn" class="btn btn-secondary">
             <i class="fas fa-copy"></i>
-            <span>复制</span>
+            <span class="lang-zh">复制</span><span class="lang-en">Copy</span>
         </button>
         <button id="exportBtn" class="btn btn-success">
             <i class="fas fa-file-export"></i>
-            <span>导出</span>
+            <span class="lang-zh">导出</span><span class="lang-en">Export</span>
         </button>
     </div>
 
@@ -57,7 +57,7 @@
         <div class="modal-dialog modal-fullscreen">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">条码扫描</h5>
+                    <h5 class="modal-title"><span class="lang-zh">条码扫描</span><span class="lang-en">Scan Barcode</span></h5>
                     <button type="button" class="btn-close" id="closeScanner" aria-label="关闭"></button>
                 </div>
                 <div class="modal-body p-0 position-relative">
@@ -68,11 +68,11 @@
                     <!-- 数量调整界面 -->
                     <div id="quantityModal" class="quantity-modal d-none">
                         <div class="scanned-info">
-                            <div class="scanned-label">已扫描条码 (可手动修改)</div>
+                            <div class="scanned-label"><span class="lang-zh">已扫描条码 (可手动修改)</span><span class="lang-en">Scanned Code (editable)</span></div>
                             <!-- 允许手动更改条码 -->
                             <div id="scannedCode" class="scanned-code mb-3 fw-bold" contenteditable="true"></div>
                         </div>
-                        <div class="quantity-label">加入Order List的数量</div>
+                        <div class="quantity-label"><span class="lang-zh">加入Order List的数量</span><span class="lang-en">Quantity to add</span></div>
                         <div class="quantity-control">
                             <button id="decreaseQty" class="btn btn-outline-secondary rounded-circle">
                                 <i class="fas fa-minus"></i>
@@ -83,10 +83,10 @@
                             </button>
                         </div>
                         <button id="confirmQty" class="btn btn-primary mt-3 w-100">
-                            确定
+                            <span class="lang-zh">确定</span><span class="lang-en">Confirm</span>
                         </button>
                         <button id="cancelQty" class="btn btn-secondary mt-2 w-100">
-                            取消
+                            <span class="lang-zh">取消</span><span class="lang-en">Cancel</span>
                         </button>
                     </div>
                 </div>
@@ -96,15 +96,15 @@
 
     <!-- Toast 消息，移除动画以减轻渲染负担 -->
     <div id="toastMessage" class="toast-message d-none">
-        <i class="fas fa-check-circle"></i> 添加成功
+        <i class="fas fa-check-circle"></i> <span class="lang-zh">添加成功</span><span class="lang-en">Added</span>
     </div>
 
     <!-- 加载指示器 -->
     <div id="loadingIndicator" class="loading-indicator d-none">
         <div class="spinner-border text-light" role="status">
-            <span class="visually-hidden">加载中...</span>
+            <span class="visually-hidden"><span class="lang-zh">加载中...</span><span class="lang-en">Loading...</span></span>
         </div>
-        <p>正在启动摄像头...</p>
+        <p><span class="lang-zh">正在启动摄像头...</span><span class="lang-en">Starting camera...</span></p>
     </div>
 
     <!-- JS 引入 -->
@@ -116,5 +116,14 @@
     <!-- 保留 HTML5QrCode 作为备用 -->
     <script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
     <script src="{{ url_for('static', filename='script.js') }}"></script>
+    <div id="langToggle" class="lang-fab"><i class="fas fa-language"></i></div>
+    <script src="{{ url_for('static', filename='lang.js') }}"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded',function(){
+        function setTitle(){ document.title = t('点货系统','Stock Counter'); }
+        setTitle();
+        document.body.addEventListener('langChanged', setTitle);
+    });
+    </script>
 </body>
 </html>

--- a/templates/mode2.html
+++ b/templates/mode2.html
@@ -11,7 +11,7 @@
     <script src="{{ url_for('static', filename='mode2.js') }}"></script>
         
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>盘点模式</title>
+    <title id="pageTitle">盘点模式</title>
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css">
     <!-- DataTables CSS -->
@@ -53,45 +53,46 @@
 </head>
 <body>
 <div class="container my-3">
-    <h2 class="text-center">盘点模式</h2>
+    <h2 class="text-center"><span class="lang-zh">盘点模式</span><span class="lang-en">Inventory Mode</span></h2>
 
     <!-- 配置区域 -->
     <div id="setupSection" class="config-section">
         <div class="mb-3">
-            <label for="fileUpload" class="form-label fw-bold">1. 上传商品清单 (Excel / CSV)</label>
+            <label for="fileUpload" class="form-label fw-bold"><span class="lang-zh">1. 上传商品清单 (Excel / CSV)</span><span class="lang-en">1. Upload Product List (Excel/CSV)</span></label>
             <input class="form-control" type="file" id="fileUpload" accept=".xlsx,.xls,.csv">
+            <p class="small text-muted mt-1"><span class="lang-zh">支持的日期格式：11 DEC 2024，11/12/2024，11.12.2014。其他格式请手动选择日期。</span><span class="lang-en">Supported date formats: 11 DEC 2024, 11/12/2024, 11.12.2014. Other formats please choose manually.</span></p>
         </div>
 
         <div class="mb-3">
-            <label class="form-label fw-bold">2. 设定日期范围 (可添加多个，不重叠)</label>
+            <label class="form-label fw-bold"><span class="lang-zh">2. 设定日期范围 (可添加多个，不重叠)</span><span class="lang-en">2. Set Date Ranges (no overlap)</span></label>
             <div class="row g-2 align-items-end">
                 <div class="col">
-                    <label class="form-label">开始日期 (可留空)</label>
+                    <label class="form-label"><span class="lang-zh">开始日期 (可留空)</span><span class="lang-en">Start Date (optional)</span></label>
                     <input type="date" id="startDate" class="form-control">
                 </div>
                 <div class="col">
-                    <label class="form-label">结束日期 (可留空)</label>
+                    <label class="form-label"><span class="lang-zh">结束日期 (可留空)</span><span class="lang-en">End Date (optional)</span></label>
                     <input type="date" id="endDate" class="form-control">
                 </div>
                 <div class="col-auto">
-                    <button id="addDateRangeBtn" class="btn btn-outline-primary"> 确认添加</button>
+                    <button id="addDateRangeBtn" class="btn btn-outline-primary"><span class="lang-zh">确认添加</span><span class="lang-en">Add</span></button>
                 </div>
             </div>
             <div id="dateRangeList" class="mt-2"></div>
 
             <!-- 手电筒开关 -->
             <div class="mt-3 d-flex align-items-center">
-                <span class="me-2">启用手电筒</span>
+                <span class="me-2"><span class="lang-zh">启用手电筒</span><span class="lang-en">Flashlight</span></span>
                 <button id="flashToggle" class="btn btn-sm btn-danger d-flex align-items-center">
                     <i class="fas fa-lightbulb me-1"></i>
-                    <span>关</span>
+                    <span class="lang-zh">关</span><span class="lang-en">Off</span>
                 </button>
             </div>
 
             <!-- 深色模式已移除 -->
         </div>
 
-        <button id="finishSetupBtn" class="btn btn-success w-100">完成配置，开始盘点</button>
+        <button id="finishSetupBtn" class="btn btn-success w-100"><span class="lang-zh">完成配置，开始盘点</span><span class="lang-en">Finish and Start</span></button>
     </div>
 
     <!-- 数据表区域 (默认隐藏) -->
@@ -104,7 +105,7 @@
 
         <!-- 提示文字 + Show entries 右对齐 -->
         <div class="d-flex justify-content-between align-items-center mb-2">
-            <p class="small text-muted mb-0" style="font-size:0.7rem; color:rgb(151, 150, 150);">* 列内数据可手动修改</p>
+            <p class="small text-muted mb-0" style="font-size:0.7rem; color:rgb(151, 150, 150);"><span class="lang-zh">* 列内数据可手动修改</span><span class="lang-en">* Cells are editable</span></p>
             <div class="form-inline" style="font-size:0.75rem;">
                 Show
                 <select id="entriesSelect" class="form-select form-select-sm d-inline-block mx-1" style="width: 45px; font-size:0.75rem; padding:2px 6px;">
@@ -122,16 +123,16 @@
             <tbody></tbody>
         </table>
         <div class="text-center mt-2">
-            <button id="addManualBtn" class="btn btn-outline-primary btn-sm"><i class="fas fa-plus"></i> 手动添加</button>
+            <button id="addManualBtn" class="btn btn-outline-primary btn-sm"><i class="fas fa-plus"></i> <span class="lang-zh">手动添加</span><span class="lang-en">Add Manually</span></button>
         </div>
     </div>
 </div>
 
 <!-- 底部按钮 -->
 <div id="actionButtons" class="bottom-buttons d-none">
-    <button id="scanBtn" class="btn btn-primary"><i class="fas fa-barcode"></i> 扫描</button>
-    <button id="copyBtn" class="btn btn-secondary"><i class="fas fa-copy"></i> 复制</button>
-    <button id="exportBtn" class="btn btn-success"><i class="fas fa-file-export"></i> 导出</button>
+    <button id="exportBtn" class="btn btn-success btn-sm"><i class="fas fa-file-export"></i> <span class="lang-zh">导出</span><span class="lang-en">Export</span></button>
+    <button id="langToggle" class="btn btn-secondary btn-sm"><i class="fas fa-language"></i></button>
+    <button id="scanBtn" class="btn btn-primary btn-sm"><i class="fas fa-barcode"></i> <span class="lang-zh">扫描</span><span class="lang-en">Scan</span></button>
 </div>
 
 <!-- 扫描模态框 -->
@@ -139,7 +140,7 @@
     <div class="modal-dialog modal-fullscreen">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">条码识别中</h5>
+                <h5 class="modal-title"><span class="lang-zh">条码识别中</span><span class="lang-en">Scanning Barcode</span></h5>
                 <button type="button" class="btn-close" id="closeScanner" aria-label="关闭"></button>
             </div>
             <div class="modal-body p-0 position-relative">
@@ -151,17 +152,17 @@
                 <!-- Loading Indicator -->
                 <div id="loadingIndicator" class="loading-indicator d-none">
                     <div class="spinner-border text-light" role="status"></div>
-                    <p>正在启动摄像头...</p>
+                    <p><span class="lang-zh">正在启动摄像头...</span><span class="lang-en">Starting camera...</span></p>
                 </div>
                 <!-- Barcode Confirmation Dialog (re-uses quantity-modal style) -->
                 <div id="barcodeConfirmContainer" class="quantity-modal d-none">
-                    <h5 class="mb-3">确认条码</h5>
-                    <p class="text-muted small mb-2">已扫描条码如下，可修改</p>
+                    <h5 class="mb-3"><span class="lang-zh">确认条码</span><span class="lang-en">Confirm Barcode</span></h5>
+                    <p class="text-muted small mb-2"><span class="lang-zh">已扫描条码如下，可修改</span><span class="lang-en">Scanned code below, editable</span></p>
                     <input type="text" id="barcodeConfirmInput" class="form-control text-center mb-3"/>
                     <div id="barcodeStatus" class="small mb-3"></div>
                     <div class="d-grid gap-2">
-                       <button id="confirmBarcodeBtn" class="btn btn-success">确认并开始识别日期</button>
-                       <button id="cancelBarcodeBtn" class="btn btn-secondary">重新识别</button>
+                       <button id="confirmBarcodeBtn" class="btn btn-success"><span class="lang-zh">确认并开始识别日期</span><span class="lang-en">Confirm and scan date</span></button>
+                       <button id="cancelBarcodeBtn" class="btn btn-secondary"><span class="lang-zh">重新识别</span><span class="lang-en">Rescan</span></button>
                     </div>
                </div>
             </div>
@@ -175,8 +176,8 @@
         <div class="modal-content bg-dark text-white">
             <div id="ocrScannerBox"></div>
             <div class="modal-header border-0">
-                <h5 class="modal-title">日期识别中</h5>
-                <button id="manualDateBtn" class="btn btn-light btn-sm d-flex align-items-center me-2"><i class="fas fa-keyboard me-1"></i> 手动输入日期</button>
+                <h5 class="modal-title"><span class="lang-zh">日期识别中</span><span class="lang-en">Detecting Date</span></h5>
+                <button id="manualDateBtn" class="btn btn-light btn-sm d-flex align-items-center me-2"><i class="fas fa-keyboard me-1"></i> <span class="lang-zh">手动选择日期</span><span class="lang-en">Select Date Manually</span></button>
                 <button type="button" class="btn-close btn-close-white" id="closeOcr" aria-label="关闭"></button>
             </div>
             <div class="modal-body d-flex flex-column justify-content-center align-items-center position-relative">
@@ -185,14 +186,16 @@
                 <button id="flashToggleInOcr" class="btn btn-danger position-absolute start-50 translate-middle-x" style="bottom: 12%; z-index: 1101; width: 48px; height:48px; border-radius:50%; display:none;">
                     <i class="fas fa-lightbulb"></i>
                 </button>
-                <div id="ocrOverlayText" class="position-absolute top-0 start-50 translate-middle-x mt-3">正在识别日期，请移动镜头对准日期...</div>
+                <div id="ocrOverlayText" class="position-absolute top-0 start-50 translate-middle-x mt-3"><span class="lang-zh">正在识别日期，请移动镜头对准日期...</span><span class="lang-en">Detecting date, please align the camera...</span></div>
+                <div id="manualSelectArea" class="d-none mt-4 text-center"></div>
                 <div class="mt-4 d-none" id="ocrConfirmArea">
-                    <h5 class="mb-3">确认日期</h5>  
-                    <p class="text-muted small mb-2">识别到日期如下(可修改)</p>
+                    <h5 class="mb-3" id="confirmTitle"><span class="lang-zh">确认日期</span><span class="lang-en">Confirm Date</span></h5>
+                    <p class="text-muted small mb-2" id="confirmDesc"><span class="lang-zh">识别到日期如下(可修改)</span><span class="lang-en">Recognized date below (editable)</span></p>
                     <input type="date" id="dateInput" class="form-control text-center mb-2"/>
+                    <div id="selectedRangeDisplay" class="mb-2 d-none"></div>
                     <div class="d-grid gap-2">
-                        <button id="confirmDateBtn" class="btn btn-success">确认</button>
-                        <button id="retryOcrBtn" class="btn btn-secondary">重新识别</button>
+                        <button id="confirmDateBtn" class="btn btn-success"><span class="lang-zh">确认</span><span class="lang-en">Confirm</span></button>
+                        <button id="retryOcrBtn" class="btn btn-secondary"><span class="lang-zh">重新识别</span><span class="lang-en">Retry</span></button>
                     </div>
                 </div>
                 <h4 id="ocrResult" class="mt-3"></h4>
@@ -203,6 +206,13 @@
 
 <!-- Toast -->
 <div id="toastMessage" class="toast-message d-none"></div>
-
+<script src="{{ url_for('static', filename='lang.js') }}"></script>
+<script>
+document.addEventListener('DOMContentLoaded',function(){
+    function setTitle(){ document.title=t('盘点模式','Inventory Mode'); }
+    setTitle();
+    document.body.addEventListener('langChanged',setTitle);
+});
+</script>
 </body>
-</html> 
+</html>

--- a/templates/select_mode.html
+++ b/templates/select_mode.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <!-- 禁止缩放 -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>选择模式</title>
+    <title id="pageTitle">选择模式</title>
     <!-- Bootstrap & FontAwesome -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -65,20 +65,31 @@
 </head>
 <body>
     <div class="mode-card animate__animated animate__fadeIn">
-        <h2 style="text-align:center;color:#000;font-weight:700;margin-bottom:1.3rem;">请选择使用模式</h2>
-        <a href="/mode1" class="btn btn-secondary btn-mode"><i class="fas fa-list"></i> 点货模式</a>
-        <a href="/mode2" class="btn btn-dark btn-mode"><i class="fas fa-boxes"></i> 盘点模式</a>
-        <a href="/tutorial" class="btn btn-tutorial btn-mode"><i class="fas fa-question-circle"></i> 教程</a>
+        <h2 style="text-align:center;color:#000;font-weight:700;margin-bottom:1.3rem;">
+            <span class="lang-zh">请选择使用模式</span><span class="lang-en">Choose Mode</span>
+        </h2>
+        <a href="/mode1" class="btn btn-secondary btn-mode"><i class="fas fa-list"></i> <span class="lang-zh">点货模式</span><span class="lang-en">Counting</span></a>
+        <a href="/mode2" class="btn btn-dark btn-mode"><i class="fas fa-boxes"></i> <span class="lang-zh">盘点模式</span><span class="lang-en">Inventory</span></a>
+        <a href="/tutorial" class="btn btn-tutorial btn-mode"><i class="fas fa-question-circle"></i> <span class="lang-zh">教程</span><span class="lang-en">Tutorial</span></a>
     </div>
     <!-- 模式说明 -->
     <div class="mode-desc small px-3">
-        <p class="mt-2">此APP仅支持如手机、平板等带摄像头的设备。</p>
-        <p class="mt-2">如仅需计数，不需要盘日期，可直接在电脑使用扫码枪版本：<a href="https://nullpointers.site:8081" class="link-light text-decoration-underline" target="_blank" style="color: black!important;">https://nullpointers.site:8081</a></p>
+        <p class="mt-2"><span class="lang-zh">此APP仅支持如手机、平板等带摄像头的设备。</span><span class="lang-en">This app works on camera-equipped devices only.</span></p>
+        <p class="mt-2"><span class="lang-zh">如仅需计数，不需要盘日期，可直接在电脑使用扫码枪版本：</span><span class="lang-en">For counting only you can use desktop version:</span><a href="https://nullpointers.site:8081" class="link-light text-decoration-underline" target="_blank" style="color: black!important;">https://nullpointers.site:8081</a></p>
         <p class="mt-2"></p>
-        <p class="mb-1">• 点货模式：此模式用于周一订货。扫描条码并输入数量即可制作点货单，适用于大店在库存不准确的情况下手动制作点货单。</p>
-        <p class="mb-1">• 盘点模式：此模式用于周四盘点（带日期）。可扫描条码统计数量，自动识别 Repair&nbsp;Parts 日期。</p>
-        <p class="mb-1">• 教程：查看详细文字和视频教程</p>
+        <p class="mb-1"><span class="lang-zh">• 点货模式：此模式用于周一订货。扫描条码并输入数量即可制作点货单，适用于大店在库存不准确的情况下手动制作点货单。</span><span class="lang-en">• Counting Mode: for Monday ordering.</span></p>
+        <p class="mb-1"><span class="lang-zh">• 盘点模式：此模式用于周四盘点（带日期）。可扫描条码统计数量，自动识别 Repair&nbsp;Parts 日期。</span><span class="lang-en">• Inventory Mode: for Thursday stock check with dates.</span></p>
+        <p class="mb-1"><span class="lang-zh">• 教程：查看详细文字和视频教程</span><span class="lang-en">• Tutorial: detailed guide</span></p>
 
     </div>
+    <div id="langToggle" class="lang-fab"><i class="fas fa-language"></i></div>
+    <script src="{{ url_for('static', filename='lang.js') }}"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded',function(){
+        function setTitle(){ document.title=t('选择模式','Select Mode'); }
+        setTitle();
+        document.body.addEventListener('langChanged',setTitle);
+    });
+    </script>
 </body>
-</html> 
+</html>

--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>使用教程</title>
+    <title id="pageTitle">使用教程</title>
     <!-- Bootstrap & FontAwesome -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -59,7 +59,7 @@
 </head>
 <body>
     <main class="container my-5">
-        <h1 class="fw-bold mb-2" style="color: black !important;padding-bottom: 1rem; font-size: 2rem;">软件使用教程</h1>
+        <h1 class="fw-bold mb-2" style="color: black !important;padding-bottom: 1rem; font-size: 2rem;"><span class="lang-zh">软件使用教程</span><span class="lang-en">Tutorial</span></h1>
         <!-- ===== 详细操作流程 ===== -->
         <section class="mb-5">
             <h3 class="fw-bold mb-2"><i class="fas fa-boxes-stacked me-2"></i>盘点模式</h3>
@@ -68,57 +68,57 @@
                 <iframe class="rounded" src="https://www.youtube.com/embed/jfrv4BqKj_U" title="Mode2 Tutorial" allowfullscreen></iframe>
             </div>
             <ol class="lh-lg ps-3">
-                <li>在首页点击「盘点模式」。</li>
-                <li>步骤&nbsp;1：<strong>上传商品清单</strong>
+                <li><span class="lang-zh">在首页点击「盘点模式」。</span><span class="lang-en">Open "Inventory Mode" from home.</span></li>
+                <li><span class="lang-zh">步骤&nbsp;1：<strong>上传商品清单</strong></span><span class="lang-en">Step 1: <strong>Upload product list</strong></span>
                     <ul>
-                        <li>点击「上传商品清单」并选择包含&nbsp;Code / Name / Count&nbsp;的文件。</li>
+                        <li><span class="lang-zh">点击「上传商品清单」并选择包含&nbsp;Code / Name / Count&nbsp;的文件。</span><span class="lang-en">Choose a file containing Code/Name/Count.</span></li>
                     </ul>
                 </li>
-                <li>步骤&nbsp;2：<strong>设定日期范围</strong>
+                <li><span class="lang-zh">步骤&nbsp;2：<strong>设定日期范围</strong></span><span class="lang-en">Step 2: <strong>Set date ranges</strong></span>
                     <ul>
-                        <li>选择开始 / 结束日期后点「确认」。可重复添加多个不重叠的范围。</li>
-                        <li>日期旁的「×」可删除对应范围。</li>
+                        <li><span class="lang-zh">选择开始 / 结束日期后点「确认」。可重复添加多个不重叠的范围。</span><span class="lang-en">Select start/end dates and confirm. Multiple non-overlapping ranges are allowed.</span></li>
+                        <li><span class="lang-zh">日期旁的「×」可删除对应范围。</span><span class="lang-en">Use "×" to delete a range.</span></li>
                     </ul>
                 </li>
-                <li>步骤&nbsp;3：点击「完成配置，开始盘点」，系统生成带日期列的统计表。</li>
-                <li>盘点过程中可选择两种方式更新数量：
+                <li><span class="lang-zh">步骤&nbsp;3：点击「完成配置，开始盘点」，系统生成带日期列的统计表。</span><span class="lang-en">Step 3: Click "Finish" to create the table with date columns.</span></li>
+                <li><span class="lang-zh">盘点过程中可选择两种方式更新数量：</span><span class="lang-en">During inventory there are two ways to update counts:</span>
                     <ul>
-                        <li><strong>扫描条码</strong>：
+                        <li><strong><span class="lang-zh">扫描条码</span><span class="lang-en">Scan barcode</span></strong>：
                             <ol class="mt-2">
-                                <li>点击底部「扫描」> 对准条码（可能需要调整角度）。</li>
-                                <li>出现「确认条码」窗口，可修改后点击「确认并识别日期」。</li>
-                                <li>摄像头会切换到日期识别，框住日期直至识别（可能需要调整角度）。</li>
-                                <li>确认日期后，系统将对应单元格数量&nbsp;+1。</li>
+                                <li><span class="lang-zh">点击底部「扫描」> 对准条码（可能需要调整角度）。</span><span class="lang-en">Tap "Scan" and aim at the code.</span></li>
+                                <li><span class="lang-zh">出现「确认条码」窗口，可修改后点击「确认并识别日期」。</span><span class="lang-en">Confirm the barcode then scan the date.</span></li>
+                                <li><span class="lang-zh">摄像头会切换到日期识别，框住日期直至识别（可能需要调整角度）。</span><span class="lang-en">Camera switches to OCR; align date until recognized.</span></li>
+                                <li><span class="lang-zh">确认日期后，系统将对应单元格数量&nbsp;+1。</span><span class="lang-en">After confirming, quantity increases by 1.</span></li>
                             </ol>
                         </li>
-                        <li><strong>直接编辑</strong>：点击任意单元格，输入数量后失焦即可保存。</li>
+                        <li><strong><span class="lang-zh">直接编辑</span><span class="lang-en">Edit directly</span></strong>：<span class="lang-zh">点击任意单元格，输入数量后失焦即可保存。</span><span class="lang-en">Click a cell and edit the number.</span></li>
                     </ul>
                 </li>
-                <li>盘点结束后，同样可使用底部「复制」或「导出」输出结果。强烈建议导出。</li>
+                <li><span class="lang-zh">盘点结束后，同样可使用底部「复制」或「导出」输出结果。强烈建议导出。</span><span class="lang-en">After finishing, use "Copy" or "Export" to save results (export recommended).</span></li>
             </ol>
         </section>
 
         <section>
-            <h3 class="fw-bold mb-2"><i class="fas fa-list-ul me-2"></i>点货模式</h3>
+            <h3 class="fw-bold mb-2"><i class="fas fa-list-ul me-2"></i><span class="lang-zh">点货模式</span><span class="lang-en">Counting Mode</span></h3>
             <!-- Mode1 视频占位 -->
             <div class="ratio ratio-16x9 mb-3">
                 <div class="d-flex align-items-center justify-content-center bg-light text-muted">Mode&nbsp;1&nbsp;视频即将上线</div>
             </div>
             <ol class="lh-lg ps-3">
-                <li>在首页点击「点货模式」。</li>
-                <li>点击底部「扫描」按钮，首次会弹出摄像头画面。</li>
-                <li>对准商品条码，系统识别后会弹出「数量调整」窗口：
+                <li><span class="lang-zh">在首页点击「点货模式」。</span><span class="lang-en">Select "Counting Mode" on home page.</span></li>
+                <li><span class="lang-zh">点击底部「扫描」按钮，首次会弹出摄像头画面。</span><span class="lang-en">Tap "Scan" to open the camera.</span></li>
+                <li><span class="lang-zh">对准商品条码，系统识别后会弹出「数量调整」窗口：</span><span class="lang-en">Aim at the barcode and adjust quantity:</span>
                     <ul>
-                        <li>如需修改条码，可直接点选并编辑。</li>
-                        <li>使用「+／-」按钮调节数量，或直接在表格里修改。</li>
-                        <li>确认无误后点击「确定」完成添加。</li>
+                        <li><span class="lang-zh">如需修改条码，可直接点选并编辑。</span><span class="lang-en">Barcode can be edited manually.</span></li>
+                        <li><span class="lang-zh">使用「+／-」按钮调节数量，或直接在表格里修改。</span><span class="lang-en">Use +/- buttons or edit the table.</span></li>
+                        <li><span class="lang-zh">确认无误后点击「确定」完成添加。</span><span class="lang-en">Press "Confirm" to add.</span></li>
                     </ul>
                 </li>
-                <li>如条码无法扫描，可点击「手动添加」，在新增行中手动输入 Code 与数量。</li>
-                <li>全部录入完成后：
+                <li><span class="lang-zh">如条码无法扫描，可点击「手动添加」，在新增行中手动输入 Code 与数量。</span><span class="lang-en">If scanning fails, use "Add Manually" to input code and quantity.</span></li>
+                <li><span class="lang-zh">全部录入完成后：</span><span class="lang-en">When finished:</span>
                     <ul>
-                        <li>点击「复制」将整表内容复制到剪贴板。</li>
-                        <li>点击「导出」生成&nbsp;Excel&nbsp;文件。</li>
+                        <li><span class="lang-zh">点击「复制」将整表内容复制到剪贴板。</span><span class="lang-en">Click "Copy" to copy the table.</span></li>
+                        <li><span class="lang-zh">点击「导出」生成&nbsp;Excel&nbsp;文件。</span><span class="lang-en">Click "Export" for an Excel file.</span></li>
                     </ul>
                 </li>
             </ol>
@@ -130,5 +130,14 @@
 
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+    <div id="langToggle" class="lang-fab"><i class="fas fa-language"></i></div>
+    <script src="{{ url_for('static', filename='lang.js') }}"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded',function(){
+        function setTitle(){ document.title=t('使用教程','Tutorial'); }
+        setTitle();
+        document.body.addEventListener('langChanged',setTitle);
+    });
+    </script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- dispatch language change events for title updates in lang.js
- update placeholders and alerts in mode2
- switch floating language toggle to button on inventory page
- add bilingual text for index and tutorial pages
- translate messages in mode1 script
- dynamically adjust titles when language changes

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687ceb60720c8333a6c9a60599d5dd51